### PR TITLE
chore(docs) fix a typo in the custom styles example

### DIFF
--- a/apps/docs/content/components/progress/custom-styles.ts
+++ b/apps/docs/content/components/progress/custom-styles.ts
@@ -12,7 +12,7 @@ export default function App() {
         label: "tracking-wider font-medium text-default-600",
         value: "text-foreground/60",
       }}
-      label="Lose weight"
+      label="Loose weight"
       value={65}
       showValueLabel={true}
     />


### PR DESCRIPTION
## 📝 Description

> Fixed a typo on the docs page

## ⛳️ Current behavior (updates)

> Typo at custom-styles example in progress component

## 🚀 New behavior

> Just fixed a typo ( Replaced "Lose" with "Loose" )

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
Docs page where the current issue is (https://nextui.org/docs/components/progress#custom-styles)
